### PR TITLE
feat!: drop EOL Laravel 10 + PHP 8.1 (require L11+, PHP 8.2+)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,13 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -23,12 +21,6 @@ jobs:
           - laravel: 13.*
             testbench: 11.*
         exclude:
-          - laravel: 11.*
-            php: 8.1
-          - laravel: 12.*
-            php: 8.1
-          - laravel: 13.*
-            php: 8.1
           - laravel: 13.*
             php: 8.2
 

--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.2",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "driftingly/rector-laravel": "^1.2",
         "laravel/pint": "^1.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0",
         "phpstan/phpstan-deprecation-rules": "^1.1.1|^2.0",
         "phpstan/phpstan-phpunit": "^1.3.3|^2.0",
-        "phpunit/phpunit": "^10.5.0|^11.0|^12.5.22",
+        "phpunit/phpunit": "^11.0|^12.0",
         "rector/rector": "^1.2"
     },
     "autoload": {


### PR DESCRIPTION
## What

Drop end-of-life Laravel 10 and PHP 8.1. New minimums:

- `php`: `^8.1` → `^8.2`
- `illuminate/support`: `^10.0|^11.0|^12.0|^13.0` → `^11.0|^12.0|^13.0`
- `orchestra/testbench` (dev): `^8.0|^9.0|^10.0|^11.0` → `^9.0|^10.0|^11.0`
- `phpunit/phpunit` (dev): `^10.5.0|^11.0|^12.5.22` → `^11.0|^12.0`
- CI matrix: drop PHP 8.1 and Laravel 10.* (+ the L10/testbench-8 include and the now-dead 8.1 excludes; kept the L13×8.2 exclude since Laravel 13 requires PHP ^8.3)

## Why

Laravel 10 hit security-EOL in **Feb 2025** and PHP 8.1 in **Nov 2025**. Supporting them is dead weight. Removing supported versions from the constraint is a consumer-breaking change, so this is a **major release**.

## Decision: strict EOL-only

I deliberately **kept Laravel 11** (security until ~Aug 2026) and **PHP 8.2** (until Dec 2026) — neither is EOL yet. A more aggressive cut to `^12|^13` / PHP `^8.3` is a one-line trim if preferred; say the word.

## Verification

Local: `composer update --prefer-stable` resolves to **Laravel 13.11.2 + testbench 11.3.3 + PHPUnit 12.5.27** on **PHP 8.5** — `vendor/bin/phpunit` → **16/16 pass, 30 assertions**. Full matrix runs in CI on this PR.

## Release

Tag **`4.0.0`** on merge (BREAKING CHANGE). composer.lock is gitignored; no lockfile change.