### PR TITLE
chore(ci): pin actions to SHAs + gate dependabot auto-merge on tests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,31 +2,52 @@ name: dependabot-auto-merge
 on: pull_request_target
 
 permissions:
-  pull-requests: write
   contents: write
+  pull-requests: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Auto-merge Dependabot PRs for semver-minor updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: gh pr merge --auto --merge "$PR_URL"
+      # Gate auto-merge on the test suite passing, then merge.
+      #
+      # We deliberately do NOT rely on branch protection / required status
+      # checks: pint.yml and update-changelog.yml push directly to main via
+      # git-auto-commit-action, and required checks on main would block those
+      # pushes. Instead we wait for the test workflow run on this PR's head SHA
+      # to finish, and only merge if it succeeded. Only semver-minor and
+      # semver-patch updates are auto-merged; majors require manual review.
+      - name: Auto-merge minor/patch updates after tests pass
+        if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
-      - name: Auto-merge Dependabot PRs for semver-patch updates
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          ok=false
+          for _ in $(seq 1 40); do
+            run=$(gh run list --repo "$REPO" --workflow run-tests.yml --limit 30 \
+                    --json headSha,status,conclusion \
+                    --jq "[.[] | select(.headSha == \"$HEAD_SHA\")][0] // {}")
+            status=$(printf '%s' "$run" | jq -r '.status // "queued"')
+            if [ "$status" = "completed" ]; then
+              [ "$(printf '%s' "$run" | jq -r '.conclusion')" = "success" ] && ok=true
+              break
+            fi
+            echo "waiting for test suite (status=${status})…"
+            sleep 30
+          done
+          if [ "$ok" != "true" ]; then
+            echo "::error::Test suite did not pass for ${HEAD_SHA}; not auto-merging."
+            exit 1
+          fi
+          gh pr merge --merge "$PR_URL"

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -8,17 +8,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@5c2bcf28d7b060ef3c601d7b476d5430a7b46c27 # v4
 
       - name: Run PHPStan
         run: vendor/bin/phpstan --error-format=github

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix code styling issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'style: resolve style guide violations'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
@@ -42,7 +42,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.os }}-php-${{ matrix.php }}-laravel-${{ matrix.laravel }}-composer-${{ matrix.stability }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,18 +10,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
## What

Two supply-chain hardening changes to the CI, following the question "is it safe to keep Dependabot auto-merge?".

### 1. Pin every GitHub Action to a commit SHA
All actions were tag-pinned (`@v6`, `@2.6`, …), so a force-re-tag of an upstream action (the laravel-lang attack class) could be pulled silently — and auto-merged. Now every `uses:` is pinned to a commit SHA with a `# vX` comment; Dependabot still bumps the SHA + comment.

### 2. Gate auto-merge on the test suite
Dependabot auto-merge previously used `gh pr merge --auto`, but `main` has **no required status checks**, so `--auto` merged as soon as the PR was mergeable — **not** when tests passed. The workflow now waits for the test run on the PR head SHA to finish and merges **only on success** (semver-minor/patch; majors stay manual).

**Why not branch protection / required checks?** Because `pint.yml` and `update-changelog.yml` push directly to `main` via `git-auto-commit-action`; required checks on `main` would block those pushes. Gating inside the workflow achieves the same guarantee without breaking the release flow.

Also normalized `fetch-metadata` to `v3.1.0` across both packages (they had drifted).

## Verification

- All 5 workflows parse as valid YAML (`yq -e`); zero `@v`/tag refs remain — every action SHA-pinned.
- The test/PHPStan/code-style runs on this PR exercise the pinned actions.
- The auto-merge gate logic only runs on actual Dependabot PRs (`pull_request_target` + `github.actor == dependabot[bot]`), so it cannot be exercised by this PR — it will be proven on the next Dependabot github-actions bump.

No release/tag; CI-only change.