### PR TITLE
chore(ci): add Composer 2.10 supply-chain audit workflow

### DIFF
--- a/.github/workflows/composer-security.yml
+++ b/.github/workflows/composer-security.yml
@@ -1,0 +1,36 @@
+# managed-by: ComposerSecurityStamp (profile=oss) — edit the stamp, not this file
+name: Composer Security
+
+permissions:
+  contents: read
+
+on:
+  push:
+    paths:
+      - 'composer.json'
+      - '.github/workflows/composer-security.yml'
+  pull_request:
+  schedule:
+    - cron: '27 6 * * 1'  # weekly — catches deps newly flagged in an unchanged lockfile
+
+jobs:
+  audit:
+    name: Malware & advisory audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup PHP + pinned Composer
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          php-version: '8.4'
+          tools: composer:2.10
+          coverage: none
+
+      - name: Resolve dependencies (library ships no lock)
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Audit (Composer >= 2.10 fails on malware + advisories)
+        run: composer audit

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,19 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "policy": {
+            "malware": {
+                "block": true,
+                "block-scope": "all"
+            },
+            "advisories": {
+                "block": true
+            },
+            "abandoned": {
+                "audit": "report"
+            }
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
Adds a dedicated Composer supply-chain audit to CI.

## What
- **`.github/workflows/composer-security.yml`** — a security job running `composer audit` (malware + known security advisories) on push, pull requests, and a weekly schedule. Uses an exact-pinned `composer:2.10`, SHA-pinned `actions/checkout` and `shivammathur/setup-php`, and `permissions: contents: read`.
- **`composer.json` `config.policy`** — malware `block-scope: all`, advisories `block: true`, abandoned `audit: report`.

## Why
Composer 2.10 makes `composer audit` fail on malware and known advisories by default. Keeping it in a separate, read-only job isolates supply-chain checks from build/test.

## Verification
- `composer validate` passes
- `composer audit` is clean — the package ships no lockfile, so the job runs `composer update` to resolve current versions