### PR TITLE
fix(ci): never auto-merge an untested head in dependabot-auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,6 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
@@ -18,12 +19,12 @@ jobs:
 
       # Gate auto-merge on the test suite passing, then merge.
       #
-      # We deliberately do NOT rely on branch protection / required status
-      # checks: pint.yml and update-changelog.yml push directly to main via
-      # git-auto-commit-action, and required checks on main would block those
-      # pushes. Instead we wait for the test workflow run on this PR's head SHA
-      # to finish, and only merge if it succeeded. Only semver-minor and
-      # semver-patch updates are auto-merged; majors require manual review.
+      # main is protected (signed commits, linear history, PR required) but has
+      # NO required status checks, so branch protection alone won't keep an
+      # untested update out. We gate here instead: wait for the test workflow
+      # run on this PR's head SHA to finish, and only merge if it succeeded.
+      # Only semver-minor and semver-patch updates are auto-merged; majors
+      # require manual review.
       - name: Auto-merge minor/patch updates after tests pass
         if: ${{ contains(fromJSON('["version-update:semver-minor", "version-update:semver-patch"]'), steps.metadata.outputs.update-type) }}
         env:
@@ -50,5 +51,7 @@ jobs:
             echo "::error::Test suite did not pass for ${HEAD_SHA}; not auto-merging."
             exit 1
           fi
+          # --match-head-commit refuses the merge if Dependabot rebased the PR
+          # after we validated HEAD_SHA, so we never merge an untested head.
           # Squash (not merge) to keep main's linear history under the branch ruleset.
-          gh pr merge --squash "$PR_URL"
+          gh pr merge --squash --match-head-commit "$HEAD_SHA" "$PR_URL"


### PR DESCRIPTION
## Problem

The dependabot auto-merge workflow validates that the test run for the PR's `head.sha` succeeded, then merges. But between that check and `gh pr merge`, Dependabot can rebase the PR onto a new head. The merge would then land a **head we never tested**.

The rationale comment was also stale — it claimed the workflow avoids branch protection because other workflows push directly to `main`. That's no longer true: the style check is read-only and the changelog update is PR-based, and `main` is protected.

## Fix

- Pass `--match-head-commit "$HEAD_SHA"` to `gh pr merge`. If the head moved after validation, the merge is refused rather than landing an untested commit.
- Add `timeout-minutes: 30` to the job so the test-polling loop can't hang indefinitely.
- Rewrite the rationale comment to match reality: `main` is protected (signed commits, linear history, PR required) but has **no required status checks**, so the test gate is enforced here in the workflow. A GitHub squash-merge keeps history linear and is signed.

No behavioural change for the normal case (tests pass, head unchanged → merge proceeds); it only closes the rebase race.